### PR TITLE
Many optimizations

### DIFF
--- a/bind.rkt
+++ b/bind.rkt
@@ -1,0 +1,51 @@
+#lang racket
+
+(require rosette/base/core/bool rosette/base/core/term)
+
+(provide (rename-out [@bind bind]) substitute substitute-all)
+
+;; Bind allows us to "perform" substitution in O(1) time, essentially
+;; by making a note that var should be substituted for value but not
+;; performing any such substitution. As a result, the substitution
+;; must be done later, incurring a cost then. However, a formula
+;; that's built up with multiple binds can pay a lower total cost to
+;; desugar than if we did substitution every single time. In addition,
+;; formulas with binds are more compact, enabling faster helpers (such
+;; as evaluate, symbolics-set, and in-formula? in util.rkt).
+
+(define (bind formula var value)
+  ;; Currently even if value is a boolean we create a bind, since
+  ;; desugaring would require a linear scan through formula.
+  (if (or (boolean? formula) (constant? formula))
+      (substitute formula var value)
+      (expression @bind formula var value)))
+
+(define-operator @bind
+  #:identifier 'bind
+  #:range T*->boolean?
+  #:unsafe bind
+  #:safe
+  (lambda (formula var value)
+    (unless (and (constant? var) (@boolean? value) (@boolean? formula))
+      (error (format "Invalid arguments to bind: ~a ~a ~a" formula var value)))
+    (bind formula var value)))
+
+;; Formula is either #t, #f, or a symbolic boolean expresion
+(define (substitute formula var expr)
+  (substitute-all formula (hash var expr)))
+
+;; Assumes that the expressions in var->expr do not contain any
+;; instances of variables that are keys to var->expr.
+(define (substitute-all formula var->expr)
+  (if (not (term? formula))
+      formula
+      (let loop ([var->expr var->expr] [formula formula])
+        (match formula
+          [(expression (== @bind) subformula bind-var value)
+           (let ([new-var->expr (hash-remove var->expr bind-var)])
+             (@bind (loop new-var->expr subformula )
+                    bind-var
+                    (loop new-var->expr value)))]
+          [(expression op args ...)
+           (apply op (map (curry loop var->expr) args))]
+          [_ (hash-ref var->expr formula formula)]))))

--- a/monoskolem.rkt
+++ b/monoskolem.rkt
@@ -8,13 +8,14 @@
 
 #lang racket
 
-(require (only-in rosette && || ! <=> define-symbolic* boolean?
-                  symbolics solve assert sat?)
+(require (only-in rosette unsat? current-solver
+                  solver-push solver-pop solver-assert solver-check)
          ;; Note that evaluate comes from util.rkt and not Rosette.
          "util.rkt")
 
-; create a symbolic boolean, shorthand
-; (define (!!) (define-symbolic* b boolean?) b)
+;;;;;;;;;;;;;
+;; Parsing ;;
+;;;;;;;;;;;;;
 
 ; number of clauses r, total variable num-var and number of x variables n
 (define r 0)
@@ -47,18 +48,13 @@
          (define clause (map string->number str-clause))
          (set! clauses (cons clause clauses))]))))
 
-(define (rosettify num-vars xs ys clauses)
+(define (rosettify num-vars xs clauses)
   (define orig-var->rosette-var
     (for/hash ([i (range 1 (add1 num-vars))])
       (cond [(member i xs)
-             (define-symbolic* x boolean?)
-             (values i x)]
-            [(member i ys)
-             (define-symbolic* y boolean?)
-             (values i y)]
+             (values i (make-symbolic-boolean x))]
             [else
-             (define-symbolic* z boolean?)
-             (values i z)])))
+             (values i (make-symbolic-boolean y))])))
 
   (define rosette-var->orig-var
     (for/hash ([(k v) orig-var->rosette-var])
@@ -76,12 +72,12 @@
     (apply || (map rosettify-literal clause)))
 
   (values (map get-rosette-var xs)
-          (map get-rosette-var ys)
           (map rosettify-formula clauses)
           get-rosette-var get-orig-var))
 
-(define (my-repr formula)
-  (formula-repr formula get-orig-var))
+;;;;;;;;;;;;;;;;
+;; Monoskolem ;;
+;;;;;;;;;;;;;;;;
 
 ;; Algorithm 1
 (define (monoskolem)
@@ -92,10 +88,10 @@
       (let* ([factors-with-var
               (filter (curry in-formula? var) factors)]
              [F (apply && factors-with-var)]
-             ;[cb0 (! (substitute F var #f))]
-             [cb1 (! (substitute F var #t))]
+             ;[cb0 (! (bind F var #f))]
+             [cb1 (! (bind F var #t))]
              [ψ (! cb1)]) ;; (combine cb0 cb1)
-        (values (cons (substitute F var ψ)
+        (values (cons (bind F var ψ)
                       (remove* factors-with-var factors))
                 (cons ψ reversed-ψs)))))
 
@@ -103,108 +99,213 @@
     (reverse-substitute (list->vector xs)
                         (list->vector (reverse reversed-ψs))))
 
-  (for-each (curry printf "~a: ~a~%")
-            x-list
-            (map my-repr (vector->list result)))
-
   result)
 
 ;; Algorithm 2
 (define (reverse-substitute x-vec ψs)
-  (for ([i (range (sub1 (vector-length ψs)) 0 -1)])
-    (printf "Reverse substituting variable ~a~%" (vector-ref x-vec i))
-    (for ([k (range (sub1 i) -1 -1)])
-      (let ([ψ-k (vector-ref ψs k)]
-            [ψ-i (vector-ref ψs i)]
-            [x-i (vector-ref x-vec i)])
-        (vector-set! ψs k (substitute ψ-k x-i ψ-i)))))
+  (display "Reverse substitute: ")
+  (time
+   (for ([i (range (sub1 (vector-length ψs)) 0 -1)])
+     ;(printf "Reverse substituting variable ~a~%" (vector-ref x-vec i))
+     (for ([k (range (sub1 i) -1 -1)])
+       (let ([ψ-k (vector-ref ψs k)]
+             [ψ-i (vector-ref ψs i)]
+             [x-i (vector-ref x-vec i)])
+         (vector-set! ψs k (bind ψ-k x-i ψ-i))))))
   ψs)
 
-(define (vector-add-to-list! vec index elem)
-  (vector-set! vec index (cons elem (vector-ref vec index))))
+;;;;;;;;;;;;;;;;;;;;;;
+;; Annotated values ;;
+;;;;;;;;;;;;;;;;;;;;;;
 
-(define (r-formula r-vec index)
-  (apply || (vector-ref r-vec index)))
+;; Annotated values keep around the sets of symbolic variables in the
+;; formulas so that in-formula? queries are O(1).
+(struct annotated-val (formula set))
+
+(define (in-formula?^ var formula)
+  (set-member? (annotated-val-set formula) var))
+
+(define (&&^ . args)
+  (annotated-val (apply && (map annotated-val-formula args))
+                 (apply set-union (map annotated-val-set args))))
+
+(define (bind^ formula var val)
+  (unless (boolean? val)
+    (error "bind^ does not currently handle non-booleans"))
+  (annotated-val (bind (annotated-val-formula formula) var val)
+                 (set-remove (annotated-val-set formula) var)))
+
+;;;;;;;;;;;;;;;
+;; R vectors ;;
+;;;;;;;;;;;;;;;
+
+;; symbolic-sets: Vector of immutable sets
+;; changes:       Vector of lists of symbolic/concrete booleans
+;; values:        Vector of symbolic/concrete booleans
+;; Invariants:
+;; The overall value at any index i is given by
+;; true-value[i] = (apply || values[i] changes[i])
+;; symbolic-sets[i] == (symbolics-set true-value[i])
+(struct rvec (symbolic-sets changes values))
+
+(define (make-rvec n)
+  (rvec (make-vector n (set))
+        (make-vector n '())
+        (make-vector n #f)))
+
+(define (rvec-add! rvec index elem)
+  (rvec-add-with-set! rvec index elem (symbolics-set elem)))
+
+(define (rvec-add!^ rvec index elem)
+  (match elem
+    [(annotated-val formula set)
+     (rvec-add-with-set! rvec index formula set)]))
+
+(define (rvec-add-with-set! rvec index elem s)
+  (define changes (rvec-changes rvec))
+  (define rvec-sets (rvec-symbolic-sets rvec))
+  (vector-set! changes index
+               (cons elem (vector-ref changes index)))
+  (vector-set! rvec-sets index
+               (set-union s (vector-ref rvec-sets index))))
+
+(define (rvec-formula rvec index)
+  (apply ||
+         (vector-ref (rvec-values rvec) index)
+         (vector-ref (rvec-changes rvec) index)))
+
+(define (consolidate-changes! rvec)
+  (define changes (rvec-changes rvec))
+  (define values (rvec-values rvec))
+  (for ([i (vector-length values)])
+    (vector-set! values i (rvec-formula rvec i))
+    (vector-set! changes i '())))
+
+;;;;;;;;;;;;;;;
+;; Algorithm ;;
+;;;;;;;;;;;;;;;
 
 (define (r1->ψ r1)
-  (vector-map (lambda (f) (! (apply || f))) r1))
+  (define n (vector-length (rvec-values r1)))
+  (for/vector #:length n ([i n]) 
+    (! (rvec-formula r1 i))))
 
 ;; Algorithm 3
 (define (init-abs-ref x-vec factors r0 r1)
   (for ([f factors])
-    (define vars-in-f (list->set (symbolics f)))
+    (define vars-in-f (symbolics-set f))
     (for ([i (in-naturals 0)]
           [var x-vec]
           #:when (set-member? vars-in-f var))
-      (let* ([with-false (substitute f var #f)]
-             [with-true  (substitute f var #t)])
-        (vector-add-to-list! r0 i (! with-false))
-        (vector-add-to-list! r1 i (! with-true))
-        (set! f (substitute f var with-true)))))
+      (let* ([with-false (bind f var #f)]
+             [with-true  (bind f var #t)])
+        (rvec-add! r0 i (! with-false))
+        (rvec-add! r1 i (! with-true))
+        (set! f (bind f var with-true)))))
 
   (r1->ψ r1))
 
-;; r-lst is an element of the r0 or r1 vectors. It is a list of formulas.
-(define (generalize π r-lst)
-  (apply || r-lst))
+;; Multiple implementations possible
+(define (generalize^ π rvec index)
+  (annotated-val (rvec-formula rvec index)
+                 (vector-ref (rvec-symbolic-sets rvec) index)))
 
 ;; Algorithm 4
 ;; r0, r1: Vector mapping each x variable to a list of formulas
 ;; pi: A sat? model (i.e. one produced by solve)
 (define (update-abs-ref x-vec r0 r1 π)
-  (define (get-r-conjunct i) (&& (r-formula r0 i) (r-formula r1 i)))
+  (define π-fn (make-evaluator π))
 
   (let* ([n (vector-length x-vec)]
-         [k (for/first ([m (range (sub1 n) -1 -1)]
-                        #:when (evaluate (get-r-conjunct m) π))
-              m)]
-         [µ0 (generalize π (vector-ref r0 k))]
-         [µ1 (generalize π (vector-ref r1 k))])
+         ;; Lemma 3a/3b says x_{n-1} cannot be the one we want, so
+         ;; start looking from x_{n-2}
+         [k (time (display "Calculate: ")
+                  (for/first ([m (range (- n 2) -1 -1)]
+                              #:when (and (π-fn (rvec-formula r0 m))
+                                          (π-fn (rvec-formula r1 m))))
+                    m))]
+         [µ0 (generalize^ π r0 k)]
+         [µ1 (generalize^ π r1 k)])
 
-    (let loop ([l  (add1 k)]
-               [µ0 µ0]
-               [µ1 µ1]
-               [µ  (&& µ0 µ1)])
-      (displayln l)
+    (let loop ([l (add1 k)] [µ (&&^ µ0 µ1)])
       (define var (vector-ref x-vec l))
-      (cond [(not (in-formula? var µ))
-             (loop (add1 l) µ0 µ1 µ)]
-            [(evaluate var π)
-             (let ([new-µ1 (substitute µ var #t)])
-               (vector-add-to-list! r1 l new-µ1)
-               (if (evaluate (r-formula r0 l) π)
-                   (let ([new-µ0 (generalize π (vector-ref r0 l))])
-                     (loop (add1 l) new-µ0 new-µ1 (&& new-µ0 new-µ1)))
+      (cond [(not (in-formula?^ var µ))
+             (loop (add1 l) µ)]
+            [(π-fn var)
+             (let ([new-µ1 (bind^ µ var #t)])
+               (rvec-add!^ r1 l new-µ1)
+               (if (time (display "Evaluate: ") (π-fn (rvec-formula r0 l)))
+                   (let ([new-µ0 (generalize^ π r0 l)])
+                     (loop (add1 l) (&&^ new-µ0 new-µ1)))
                    'done))]
             [else
-             (let ([new-µ0 (substitute µ var #f)])
-               (vector-add-to-list! r0 l new-µ0)
-               (let ([new-µ1 (generalize π (vector-ref r1 l))])
-                 (loop (add1 l) new-µ0 new-µ1 (&& new-µ1 new-µ0))))]))
-
-    (r1->ψ r1)))
+             (let ([new-µ0 (bind^ µ var #f)])
+               (rvec-add!^ r0 l new-µ0)
+               (let ([new-µ1 (generalize^ π r1 l)])
+                 (loop (add1 l) (&&^ new-µ0 new-µ1))))]))))
 
 ;; Algorithm 5
 (define (cegar-skolem x-vec factors)
-  (let* ([n            (vector-length x-vec)]
-         [r0           (make-vector n '())]
-         [r1           (make-vector n '())]
-         [x->fresh-var (for/hash ([x x-vec])
-                         (define-symbolic* fresh-x boolean?)
-                         (values x fresh-x))]
-         [F            (apply && factors)]
-         [F-fresh      (substitute-all F x->fresh-var)])
+  (define (make-extra) (make-symbolic-boolean extra))
 
-    (let loop ([ψ (init-abs-ref x-vec factors r0 r1)])
-      (let* ([equivalences (apply && (vector->list (vector-map <=> x-vec ψ)))]
-             [ε            (&& F-fresh equivalences (! F))]
-             [π            (solve (assert ε))])
-        ;(printf "Current values:~%r0:  ~a~%r1:  ~a~%psi: ~a~%ε:   ~a~%" r0 r1 ψ ε)
-        (when (sat? π)
-          (printf "Found a counterexample!~%" #;π)
-          (loop (update-abs-ref x-vec r0 r1 π)))))
+  ;; extras: List of symbolic boolean variables
+  (define (solve-with-extras extras-list)
+    (solver-push (current-solver))
+    (solver-assert (current-solver) extras-list)
+    (begin0 (time (display "SAT solver: ") (solver-check (current-solver)))
+      (solver-pop (current-solver) 1)))
+
+  (let* ([n            (vector-length x-vec)]
+         [r0           (make-rvec n)]
+         [r1           (make-rvec n)]
+         [init-ψ       (init-abs-ref x-vec factors r0 r1)]
+         [x->fresh-var (for/hash ([x x-vec])
+                         (values x (make-symbolic-boolean fresh-x)))]
+         [F            (apply && factors)]
+         [F-fresh      (bind-all F x->fresh-var)]
+         [extras       (build-vector n (lambda (i) (make-extra)))]
+         [equivalences (for/fold ([result #t])
+                                 ([x x-vec] [p init-ψ] [extra extras])
+                         (&& (<=> x (&& p extra)) result))]
+         [ε            (&& F-fresh equivalences (! F))])
+
+    (solver-assert (current-solver) (list (desugar-binds ε)))
+    (define π (solve-with-extras (vector->list extras)))
+    (for ([i (in-naturals 1)]
+          #:break (unsat? π))
+      (consolidate-changes! r0)
+      (consolidate-changes! r1)
+      ;; update-abs-ref will create new changes which we then send to
+      ;; the SAT solver incrementally
+      (time (begin0 (update-abs-ref x-vec r0 r1 π) (display "Update: ")))
+      (define new-asserts
+        (time
+         (display "New asserts: ")
+         (for/list ([i (in-naturals 0)]
+                    [change (rvec-changes r1)]
+                    #:unless (null? change))
+           (define old-extra (vector-ref extras i))
+           (define new-extra (make-extra))
+           (vector-set! extras i new-extra)
+           ;; TODO: We're forced to desugar-binds here because Rosette
+           ;; can't encode binds. However, this leads to a blowup in
+           ;; the size of the formula (which binds were meant to avoid
+           ;; in the first place). There is probably speedup to be
+           ;; gained by rewriting enc to understand binds and produce
+           ;; a result that avoids formula blowup.
+           (<=> old-extra (apply && new-extra
+                                 (map (compose ! desugar-binds) change))))))
+
+      (time (display "Solver assert: ")
+            (solver-assert (current-solver) new-asserts))
+      (time (set! π (solve-with-extras (vector->list extras)))
+            (printf "~a. solve-with-extras: " i)))
+
     (reverse-substitute x-vec (r1->ψ r1))))
 
+;;;;;;;;;;;;;;
+;; Examples ;;
+;;;;;;;;;;;;;;
 
 (parse-dimacs-formula "test.qdimacs")
 
@@ -218,8 +319,29 @@
 ; (displayln "clauses")
 ; (writeln clauses)
 
-(define-values (xs ys rosette-clauses get-rosette-var get-orig-var)
-  (rosettify num-var x-list y-list clauses))
+(define-values (xs rosette-clauses get-rosette-var get-orig-var)
+  (rosettify num-var x-list clauses))
 
-;(monoskolem)
-(cegar-skolem (list->vector xs) rosette-clauses)
+(define (my-repr formula)
+  (formula-repr formula get-orig-var))
+
+(define (order xs clauses)
+  ;; Order the xs in order of the number of times they appear in clauses
+  (define x->count (make-hash (for/list ([x xs]) (cons x 0))))
+  (for* ([clause clauses] [x (symbolics-set clause)])
+    (hash-set! x->count x (add1 (hash-ref x->count x))))
+
+  (map car (sort (for/list ([(x c) x->count]) (cons x c))
+                 (lambda (x y) (< (cdr x) (cdr y))))))
+
+(define ordered-xs (order xs clauses))
+
+(define result
+  ;(monoskolem)
+  (cegar-skolem (list->vector ordered-xs) rosette-clauses))
+
+(displayln "Solved! Printing the results:")
+
+(for-each (curry printf "~a: ~a~%")
+          (map get-orig-var ordered-xs)
+          (map (compose nnf desugar-binds) (vector->list result)))

--- a/skosette-test.rkt
+++ b/skosette-test.rkt
@@ -1,0 +1,128 @@
+#lang rosette
+
+(require rackunit rackunit/text-ui)
+(require "bind.rkt" "util.rkt")
+
+(define tests
+  (test-suite
+   "Tests for Skosette"
+
+   (let ([a (make-symbolic-boolean a)]
+         [b (make-symbolic-boolean b)]
+         [c (make-symbolic-boolean c)])
+
+     ;; We no longer do bind simplification.
+     #;(test-case "Bind simplification rules"
+       ;; Substitution for simple values of the formula
+       (check-equal? (bind #t a b) #t)
+       (check-equal? (bind #f c b) #f)
+       (check-equal? (bind a b c) a)
+       (check-equal? (bind a a b) b)
+       ;; Subsitution for simple values of the variable to be bound
+       (check-equal? (bind (&& a (! b)) b #t) #f)
+       (check-equal? (bind (&& a (! b)) b #f) a)
+       (check-equal? (bind (&& a (! b)) b a)  #f)
+       ;; We don't check that the variable being bound is present in
+       ;; the formula
+       (check-true (term? (bind (|| b c) a (! b)))))
+
+     #;(test-case "Nested binds"
+       ;; No simplification
+       (check-true (term? (bind (bind (|| a b c) a (&& b c)) b (! c))))
+       ;; Simplification of the inner bind
+       (check-equal? (bind (bind (|| a b c) a b) b (! c))
+                     (bind (|| b c) b (! c)))
+       ;; Simplification of both binds
+       (check-equal? (bind (bind (|| a b c) a b) b c)
+                     c)
+       ;; Simplification of the outer bind
+       (check-equal? (bind (bind (|| a b c) a (! b)) c b)
+                     (bind (|| a b) a (! b)))
+
+       ;; Nested binds that bind the same variable
+       ;; Outer bind simplified
+       (check-equal? (bind (bind (|| a b c) a (! b)) a b)
+                     (bind (|| a b c) a (! b)))
+       ;; Inner bind simplified
+       (check-equal? (bind (bind (|| a b c) a b) a (! b))
+                     (bind (|| b c) a (! b)))
+       ;; Both binds simplified
+       (check-equal? (bind (bind (|| a b c) a #t) a #f)
+                     #t))
+
+     #;(test-case "bind-all"
+       (check-equal? (bind-all (|| a b c) (hash a c b #t)) #t)
+       (check-equal? (bind-all (|| a b c) (hash a c b c)) c)
+       (check-equal? (bind-all (|| a b c) (hash a c b (! c)))
+                     (bind (|| b c) b (! c))))
+
+     (let* ([c1 #t]
+            [c2 #f]
+            [t1 a]
+            [t2 (|| (! a) b)]
+            [t3 (&& a (|| (&& b c) (! a)) b)]
+            [t4 (bind (&& a b) b (! a))]
+            [t5 (bind (&& a b) b (! c))]
+            [t6 (&& (! c) (bind (|| b c) c (! b)))]
+            [t7 (bind (&& a b) a (bind (|| b c) b (! c)))]
+            [all-formulas (list c1 c2 t1 t2 t3 t4 t5 t6 t7)])
+       (test-case "symbolics-set"
+         (check-equal? (symbolics-set c1) (set))
+         (check-equal? (symbolics-set c2) (set))
+         (check-equal? (symbolics-set t1) (set a))
+         (check-equal? (symbolics-set t2) (set a b))
+         (check-equal? (symbolics-set t3) (set a b c))
+         (check-equal? (symbolics-set t4) (set a))
+         (check-equal? (symbolics-set t5) (set a c))
+         (check-equal? (symbolics-set t6) (set b c))
+         (check-equal? (symbolics-set t7) (set b c)))
+
+       (test-case "evaluate"
+         (let ([m (solve (assert (&& a b (! c))))])
+           (check-true  (evaluate c1 m))
+           (check-false (evaluate c2 m))
+           (check-true  (evaluate t1 m))
+           (check-true  (evaluate t2 m))
+           (check-false (evaluate t3 m))
+           (check-false (evaluate t4 m))
+           (check-true  (evaluate t5 m))
+           (check-true  (evaluate t6 m))
+           (check-true  (evaluate t7 m))))
+
+       (test-case "in-formula?"
+         (for* ([formula all-formulas]
+                [variable (list a b c)])
+           (check-equal? (in-formula? variable formula)
+                         (set-member? (symbolics-set formula) variable))))
+
+       (test-case "desugar-binds"
+         (define desugared-formulas (map desugar-binds all-formulas))
+         (for ([config (list (&&    a     b  c) (&&    a     b  (! c))
+                             (&&    a  (! b) c) (&&    a  (! b) (! c))
+                             (&& (! a)    b  c) (&& (! a)    b  (! c))
+                             (&& (! a) (! b) c) (&& (! a) (! b) (! c)))])
+           (define m (solve (assert config)))
+           (for ([formula all-formulas])
+             ;; desugar-binds should produce an equivalent formula
+             (let ([desugared (desugar-binds formula)])
+               (check-equal? (evaluate desugared m)
+                             (evaluate formula m)
+                             (format "Formula: ~a, Desugared: ~a, Model: ~a"
+                                     formula desugared m)))
+             ;; desugar-binds-fresh-vars should be equisatisfiable
+             (let* ([desugared (desugar-binds-with-fresh-vars formula)]
+                    [to-check (&& config desugared)])
+               (check-equal? (if (term? to-check)
+                                 (sat? (solve (assert to-check)))
+                                 to-check)
+                             (evaluate formula m)
+                             (format "Formula: ~a, Desugared: ~a, Model: ~a"
+                                     formula desugared m))))))
+     ))))
+
+(define (run-skosette-tests)
+  (displayln "Running tests for bind.rkt and util.rkt")
+  (run-tests tests))
+
+(module+ main
+  (run-skosette-tests))

--- a/util.rkt
+++ b/util.rkt
@@ -1,45 +1,179 @@
 #lang racket
 
-(require (only-in rosette term? constant? expression && || ! model))
+(require (only-in rosette && || ! <=> define-symbolic* boolean?
+                  solver-assert term? constant? expression model)
+         "bind.rkt")
 
-(provide evaluate in-formula? substitute substitute-all formula-repr)
+(provide evaluate make-evaluator in-formula?
+         bind bind-all substitute substitute-all
+         desugar-binds desugar-binds-with-fresh-vars nnf formula-repr
+         make-symbolic-boolean && || ! <=> symbolics-set)
 
-;; Formula is a symbolic boolean expresion
-(define (fold-formula formula leaf-fn internal-node-fn)
+(define-syntax-rule (make-symbolic-boolean var)
+  (let ()
+    (define-symbolic* var boolean?)
+    var))
+
+;; Counterpart to Rosette's symbolics that can understand bind.
+;; One difference is that this returns an immutable set instead of a
+;; list. See also the comments on in-formula?
+;; Ensures: var \in (symbolics-set f) iff (in-formula? var f).
+(define (symbolics-set formula)
+  (let ([result (set)])
+    (let loop ([formula formula])
+      (when (term? formula)
+        (match formula
+          [(expression (== bind) subformula var value)
+           (define already-in-set? (set-member? result var))
+           (loop value) (loop subformula)
+           (unless already-in-set?
+             (set! result (set-remove result var)))]
+          [(expression op args ...)
+           (for-each loop args)]
+          [_ (set! result (set-add result formula))])))
+    result))
+
+;; Counterpart to Rosette's evaluate that can understand bind
+(define (evaluate formula m)
+  (evaluate-with-hash (model m) formula))
+
+(define (evaluate-with-hash var->val formula)
   (if (not (term? formula))
       formula
-      (let loop ([formula formula])
-        (match formula
-          [(expression op args ...)
-           (apply internal-node-fn op (map loop args))]
-          [_ (leaf-fn formula)]))))
+      (match formula
+        [(expression (== bind) subformula var value)
+         (evaluate-with-hash (hash-set var->val var
+                                       (evaluate-with-hash var->val value))
+                             subformula)]
+        [(expression (== &&) args ...)
+         (andmap (curry evaluate-with-hash var->val) args)]
+        [(expression (== ||) args ...)
+         (ormap (curry evaluate-with-hash var->val) args)]
+        [(expression op args ...)
+         (apply op (map (curry evaluate-with-hash var->val) args))]
+        [_ (hash-ref var->val formula #f)])))
 
-(define (evaluate formula m)
-  (fold-formula formula
-                (lambda (v) (hash-ref (model m) v #f))
-                (lambda (op . args) (apply op args))))
+;; If you are doing multiple evaluation queries against the same
+;; model, it can help to cache the results.
+;; In general, the evaluator loop takes both var->val and formula (see
+;; evaluate-with-hash above), but putting both of those in as keys
+;; would probably take too much time and memory. Instead, we only
+;; cache when var->val is empty, in which case the key is the
+;; formula. If we see a bind (which adds a value to var->val), then we
+;; go back to using the uncached evaluate-with-hash.
+(define (make-evaluator m)
+  (define var->val (model m))
+  (define cache (make-hash))
+  (define (loop formula)
+    (cond [(not (term? formula))
+           formula]
+          [(hash-has-key? cache formula)
+           (hash-ref cache formula)]
+          [else
+           (define result
+             (match formula
+               [(expression (== bind) subformula var value)
+                (evaluate-with-hash (hash-set var->val var (loop value))
+                                    subformula)]
+               [(expression (== &&) args ...)
+                (andmap loop args)]
+               [(expression (== ||) args ...)
+                (ormap loop args)]
+               [(expression op args ...)
+                (apply op (map loop args))]
+               [_ (hash-ref var->val formula #f)]))
+           (hash-set! cache formula result)
+           result]))
+  loop)
 
+;; Checks if var is in formula.
+;; Note that because of bind, it is not simply a matter of checking
+;; whether var appears anywhere in the structure of formula -- in
+;; something of the form (bind f var val), var is not in the formula.
 (define (in-formula? var formula)
-  (and (term? formula)
-       (fold-formula formula
-                     (curry equal? var)
-                     (lambda (op . args) (ormap identity args)))))
+  (let loop ([formula formula])
+    (match formula
+      [(expression (== bind) subformula bind-var value)
+       (and (not (eq? var bind-var))
+            (or (loop value) (loop subformula)))]
+      [(expression op args ...)
+       (ormap loop args)]
+      ;; #t, #f, or symbolic boolean variable
+      [_ (eq? var formula)])))
 
-;; Formula is either #t, #f, or a symbolic boolean expresion
-(define (substitute formula var expr)
-  (fold-formula formula
-                (lambda (v) (if (equal? var v) expr v))
-                (lambda (op . args) (apply op args))))
+;; Desugars a formula, producing an equivalent formula that has no
+;; occurrences of bind.
+(define desugar-binds-cache (make-hash))
+(define (desugar-binds formula)
+  (let loop ([var->final-val (hash)] [formula formula])
+    (match formula
+      [(expression (== bind) subformula var value)
+       (if (hash-has-key? desugar-binds-cache formula)
+           (let ([new-formula (hash-ref desugar-binds-cache formula)])
+             (if (hash-empty? var->final-val)
+                 new-formula
+                 (loop var->final-val new-formula)))
+           (let* ([final-value (loop var->final-val value)]
+                  [new-hash (hash-set var->final-val var final-value)]
+                  [result (loop new-hash subformula)])
+             (when (hash-empty? var->final-val)
+               (hash-set! desugar-binds-cache formula result))
+             result))]
+      [(expression op args ...)
+       (apply op (map (curry loop var->final-val) args))]
+      ;; #t, #f, or symbolic boolean variable
+      [_ (hash-ref var->final-val formula formula)])))
 
-(define (substitute-all formula var->expr)
-  (fold-formula formula
-                (lambda (v) (hash-ref var->expr v v))
-                (lambda (op . args) (apply op args))))
+;; Desugars a formula, removing all occurrences of bind from it.
+;; Produces a smaller formula than desugar-binds that has new free
+;; variables, so that it is equisatisfiable but not equivalent.
+(define (desugar-binds-with-fresh-vars formula)
+  (define fresh-var-constraints '())
+  (define base-formula
+    (let loop ([var->fresh-var (hash)] [formula formula])
+      (match formula
+        [(expression (== bind) subformula var value)
+         (define-symbolic* tmp boolean?)
+         (set! fresh-var-constraints
+               (cons (<=> tmp (loop var->fresh-var value))
+                     fresh-var-constraints))
+         (loop (hash-set var->fresh-var var tmp) subformula)]
+        [(expression op args ...)
+         (apply op (map (curry loop var->fresh-var) args))]
+        ;; #t, #f, or symbolic boolean variable
+        [_ (hash-ref var->fresh-var formula formula)])))
+  (apply && base-formula fresh-var-constraints))
+
+(define (bind-all formula var->expr)
+  (for/fold ([formula formula])
+            ([var (hash-keys var->expr)])
+    (bind formula var (hash-ref var->expr var))))
+
+;; Doesn't deal with bind, <=> and =>
+;; If any of those are present, the returned formula will be
+;; equivalent but may not be in NNF.
+(define (nnf formula)
+  (match formula
+    [(expression (== !) (expression (== ||) args ...))
+     (apply && (map (compose nnf !) args))]
+    [(expression (== !) (expression (== &&) args ...))
+     (apply || (map (compose nnf !) args))]
+    [(expression op args ...)
+     (apply op (map nnf args))]
+    [_ formula]))
 
 (define (formula-repr formula var->number-fn)
-  (fold-formula formula
-                (lambda (v) (var->number-fn v))
-                (lambda (op . args) (cons (op-name op) args))))
+  (let loop ([var->val (hash)] [formula formula])
+    (if (not (term? formula))
+        formula
+        (match formula
+          [(expression (== bind) subformula var value)
+           (loop (hash-set var->val var value) subformula)]
+          [(expression op args ...)
+           (cons (op-name op) (map (curry loop var->val) args))]
+          [_ (if (hash-has-key? var->val formula)
+                 (loop var->val (hash-ref var->val formula))
+                 (var->number-fn formula))]))))
 
 (define (op-name op)
   (string->symbol (with-output-to-string (thunk (write op)))))


### PR DESCRIPTION
Timing code and printing code have been left in, since it is still too slow.

At this point the calls to `evaluate` and `desugar-binds` are the bottlenecks. I suspect that this simply means that we're at the point where we need to switch to a different representation, such as AIGs or ROBDDs, in which case we shouldn't bother using Rosette. (Already a lot of the code is redoing some work that Rosette does in order to be more efficient -- at this point we're using Rosette simply to write the formulas out to Z3.)

It would be helpful to get some idea of how much work is left to be done -- how many iterations does the original implementation take to solve the various benchmarks? We haven't changed the algorithm so it will probably be similar for us (though of course randomness from the SAT solver will make it not exactly the same). If it's ~300 iterations, then we can probably get there. If it's less than 300 iterations, there's probably a bug in our code. If it's many thousands of iterations, we should give up now.